### PR TITLE
Update writing_about_ethnicity.html

### DIFF
--- a/application/templates/static_site/static_pages/style_guide/writing_about_ethnicity.html
+++ b/application/templates/static_site/static_pages/style_guide/writing_about_ethnicity.html
@@ -72,7 +72,7 @@ phrases we use and avoid, and why we don’t use BAME or BME{% endblock %}
 
     <p class="govuk-body">This page describes the government’s preferred style for writing about ethnicity.</p>
 
-    <p class="govuk-body">It was last updated in December 2021.</p>
+    <p class="govuk-body">It was last updated in October 2024.</p>
 
 
     <h2 class="govuk-heading-l govuk-!-margin-top-4"
@@ -92,14 +92,14 @@ phrases we use and avoid, and why we don’t use BAME or BME{% endblock %}
     <h3 class="govuk-heading-m"
         id="ethnic-minorities">Ethnic minorities</h3>
 
-    <p class="govuk-body">We use ‘ethnic minorities’ to refer to all ethnic groups except the white British group.
-      Ethnic minorities include white minorities, such as Gypsy, Roma and Irish Traveller groups.</p>
+    <p class="govuk-body">We use ‘ethnic minorities’ to refer to all ethnic groups except the White British group.
+      Ethnic minorities include White minorities, such as Gypsy, Roma and Irish Traveller groups.</p>
 
-    <p class="govuk-body">For comparisons with the white group as a whole, we use ‘all other ethnic groups combined’ or
-      ‘ethnic minorities (excluding white minorities)’. We also refer to ‘white’ and ‘other than white’ if space is
+    <p class="govuk-body">For comparisons with the White group as a whole, we use ‘all other ethnic groups combined’ or
+      ‘ethnic minorities (excluding white minorities)’. We also refer to ‘White’ and ‘other than White’ if space is
       limited.</p>
 
-    <p class="govuk-body">We do not use ‘non-white’ because defining groups in relation to the white majority was not
+    <p class="govuk-body">We do not use ‘non-White’ because defining groups in relation to the White majority was not
       well received in user research.</p>
 
     <div class="govuk-inset-text">You can see a <a class="govuk-link"
@@ -115,19 +115,19 @@ phrases we use and avoid, and why we don’t use BAME or BME{% endblock %}
       collection.</p>
 
     <p class="govuk-body">If we need to, we refer to either ‘aggregated’ ethnic groups or ethnic groups ‘as a whole’.
-      For example, ‘the black ethnic group as a whole’.</p>
+      For example, ‘the Black ethnic group as a whole’.</p>
 
     <h3 class="govuk-heading-m"
         id="phrasing">Phrasing</h3>
 
-    <p class="govuk-body">In research, ‘people from a black Caribbean background’, ‘the black ethnic group’ and ‘black
+    <p class="govuk-body">In research, ‘people from a Black Caribbean background’, ‘the Black ethnic group’ and ‘Black
       people’ were all acceptable phrases. ‘Blacks’ was not.</p>
 
-    <p class="govuk-body">Similarly ‘people from a white British background’, ‘the white ethnic group’ and ‘white
+    <p class="govuk-body">Similarly ‘people from a White British background’, ‘the White ethnic group’ and ‘White
       people’ are all acceptable.</p>
 
-    <p class="govuk-body">However, we don’t say ‘mixed people’ or ‘mixed race people’. We usually say ‘people with a
-      mixed ethnic background’ or ‘people from the mixed ethnic group’.</p>
+    <p class="govuk-body">However, we don’t say ‘Mixed people’ or ‘Mixed race people’. We usually say ‘people with a
+      Mixed ethnic background’ or ‘people from the Mixed ethnic group’.</p>
 
     <h3 class="govuk-heading-m"
         id="gypsy-roma-and-traveller-ethnic-groups">Gypsy, Roma and Traveller ethnic groups</h3>
@@ -144,7 +144,7 @@ phrases we use and avoid, and why we don’t use BAME or BME{% endblock %}
       <li>Roma, understood to be more recent migrants from Central and Eastern Europe</li>
     </ul>
 
-    <p class="govuk-body">The term ‘traveller’ can also encompass groups that travel. This includes, but is not limited
+    <p class="govuk-body">The term ‘Traveller’ can also encompass groups that travel. This includes, but is not limited
       to, ‘new travellers’, ‘boaters’, ‘bargees’ and ‘showpeople’.</p>
 
     <p class="govuk-body">We differentiate between Gypsy, Roma and Irish Traveller groups if data is collected for them
@@ -154,17 +154,17 @@ phrases we use and avoid, and why we don’t use BAME or BME{% endblock %}
       refer to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>‘the white Gypsy and Roma ethnic group’ or ‘white Gypsy and Roma people’</li>
-      <li>‘the white Gypsy and Irish Traveller ethnic group’ or ‘white Gypsy and Irish Traveller people’</li>
+      <li>‘the White Gypsy and Roma ethnic group’ or ‘White Gypsy and Roma people’</li>
+      <li>‘the White Gypsy and Irish Traveller ethnic group’ or ‘White Gypsy and Irish Traveller people’</li>
     </ul>
 
 
     <h2 class="govuk-heading-l govuk-!-margin-top-4"
         id="bame-and-bme">3. BAME and BME</h2>
 
-    <p class="govuk-body">We do not use the terms BAME (black, Asian and minority ethnic) and BME (black and minority
-      ethnic) because they emphasise certain ethnic minority groups (Asian and black) and exclude others
-      (mixed, other and white ethnic minority groups). The terms can also mask disparities between different ethnic
+    <p class="govuk-body">We do not use the terms BAME (Black, Asian and minority ethnic) and BME (Black and minority
+      ethnic) because they emphasise certain ethnic minority groups (Asian and Black) and exclude others
+      (Mixed, Other and White ethnic minority groups). The terms can also mask disparities between different ethnic
       groups and create misleading interpretations of data.</p>
 
     <p class="govuk-body">In March 2021, the Commission on Race and Ethnic Disparities <a class="govuk-link"
@@ -185,21 +185,12 @@ phrases we use and avoid, and why we don’t use BAME or BME{% endblock %}
         id="ordering-and-style">4. Ordering and style</h2>
 
     <h3 class="govuk-heading-m"
-        id="capitalisation">Capitalisation</h3>
-
-    <p class="govuk-body">The government’s preferred style is not to capitalise ethnic groups, (such as ‘black’ or
-      ‘white’) unless that group’s name includes a geographic place (for example, ’Asian’, ‘Indian’ or ‘black
-      Caribbean’).</p>
-
-    <p class="govuk-body">From December 2021, all RDU publications use this style.</p>
-
-    <h3 class="govuk-heading-m"
         id="order-of-ethnic-categories">Order of ethnic categories</h3>
 
-    <p class="govuk-body">Ethnic groups are ordered alphabetically in charts and tables, with ‘other’, and occasionally
+    <p class="govuk-body">Ethnic groups are ordered alphabetically in charts and tables, with ‘Other’, and occasionally
       ‘unknown’, as a final category.</p>
 
-    <p class="govuk-body">In user research, some people were offended when white was placed first in a list of ethnic
+    <p class="govuk-body">In user research, some people were offended when White was placed first in a list of ethnic
       groups, while others did not like inconsistent ordering.</p>
 
     <h3 class="govuk-heading-m govuk-!-margin-top-4"


### PR DESCRIPTION
Reintroduce title caps to ethnic groups and remove section on the previous government’s preferred style not to capitalise ethnic groups.